### PR TITLE
Ensure that volume mounts survive temporary disconnects to the remote.

### DIFF
--- a/pkg/sftp/volume.go
+++ b/pkg/sftp/volume.go
@@ -2,16 +2,18 @@ package sftp
 
 import (
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/go-plugins-helpers/volume"
 )
 
 type volumeDir struct {
-	*mount
+	*remoteMount
 	remoteDir string
 	usedBy    []string
 	createdAt time.Time
+	mounted   atomic.Bool
 }
 
 func (v *volumeDir) logicalMountPoint() string {
@@ -23,5 +25,11 @@ func (v *volumeDir) asVolume(name string) *volume.Volume {
 		Name:       name,
 		Mountpoint: v.logicalMountPoint(),
 		CreatedAt:  v.createdAt.Format(time.RFC3339),
+		Status: map[string]any{
+			"host":      v.host,
+			"port":      v.port,
+			"remoteDir": v.remoteDir,
+			"usedBy":    v.usedBy,
+		},
 	}
 }


### PR DESCRIPTION
When using Telepresence for docker compose, it's not uncommon to stop and start containers that are engaged in such a way that they provide volume mounts from the remote host. A `stop` ends the engagement and a `start` reengages. Any mounts made for remote volumes must then find the volume again using the same IP and port, even if the remote host has been temporarily unavailable.

This commit ensures that info about the remote volume is kept until the volume is deleted so that a reconnection attempt is made. A failure to reconnect will make the driver forget the remote.